### PR TITLE
Change python import functionality to print full stacktrace

### DIFF
--- a/flexgui/src/libflexgui/startup.py
+++ b/flexgui/src/libflexgui/startup.py
@@ -11,6 +11,8 @@ from PyQt6.QtOpenGLWidgets import QOpenGLWidget
 
 import linuxcnc, hal
 
+import traceback
+
 from libflexgui import actions
 from libflexgui import commands
 from libflexgui import dialogs
@@ -1747,7 +1749,7 @@ def setup_import(parent):
 			module = importlib.import_module(module_name)
 			module.startup(parent)
 		except Exception as e:
-			print(e)
+			print(traceback.format_exc())
 			msg = (f'The file {module_name} was\n'
 				'not found, check for file name\n'
 				'or there was an error in the imported\n'


### PR DESCRIPTION
print(e) helped, but in a long file with logs of instances of similar messages, it was still ambiguous. Modified it to use traceback to print the full stacktrace, eg...

before:
`TypeError: argument 2 must be str, not int`

after
```
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/libflexgui/startup.py", line 1750, in setup_import
    module.startup(parent)
  File "/home/cnc/linuxcnc/configs/qtpyvcp_grinder_touch/rpi_grinder_touch/grinder.py", line 47, in startup
    parent.grinder_window.load_settings()
  File "/home/cnc/linuxcnc/configs/qtpyvcp_grinder_touch/rpi_grinder_touch/grinder.py", line 212, in load_settings
    self.set_hal("x_min", self.settings.get('x_min',0))
  File "/home/cnc/linuxcnc/configs/qtpyvcp_grinder_touch/rpi_grinder_touch/grinder.py", line 199, in set_hal
    hal.set_p("grinder."+field, value)
TypeError: argument 2 must be str, not int

```